### PR TITLE
Fix date formatting

### DIFF
--- a/backend.php
+++ b/backend.php
@@ -321,9 +321,9 @@ class WprssFeeds {
         'title'=>$item->get_title(),
         'guid'=>$item->get_id(),
         'link'=>$item->get_link(),//TODO 
-        'updated'=>date ("Y-m-d H:m:s"),
+        'updated'=>date ("Y-m-d H:i:s"),
         'content'=>$item->get_content(),//TODO
-        'entered' =>date ("Y-m-d H:m:s"), 
+        'entered' =>date ("Y-m-d H:i:s"),
         'author' => $name
       ));
     }
@@ -336,7 +336,7 @@ class WprssFeeds {
     $feeds = $wpdb->prefix.$tbl_prefix. "feeds";
       $ret = $wpdb->update(
         $feeds,//the table
-        array('last_updated'=>date("Y-m-d H:m:s")),//columns to update
+        array('last_updated'=>date("Y-m-d H:i:s")),//columns to update
         array('id'=>$feed_id)//where filters
       );
     //echo $feedrow->feed_url;
@@ -493,9 +493,9 @@ class WprssEntries{
       'title'=>$entry['title'],
       'guid'=>$entry['guid'],
       'link'=>$entry['link'],//TODO 
-      'updated'=>date ("Y-m-d H:m:s"),
+      'updated'=>date ("Y-m-d H:i:s"),
       'content'=>$entry['content'],//TODO
-      'entered' =>date ("Y-m-d H:m:s"), 
+      'entered' =>date ("Y-m-d H:i:s"),
       'author' => $entry['author']
     ));
     $entry_id = $wpdb->insert_id;
@@ -513,7 +513,7 @@ class WprssEntries{
     //update the last updated time for the feed
     $resp->last_update = $wpdb->update(
       $feeds,//the table
-      array('last_updated' => date ("Y-m-d H:m:s")),//columns to update
+      array('last_updated' => date ("Y-m-d H:i:s")),//columns to update
       array(//where filters
         'id' =>$entry['feed_id'] //current feed
       )

--- a/install_upgrade.php
+++ b/install_upgrade.php
@@ -133,9 +133,9 @@ function wprss_install_data(){
     'title'=>'Welcome to Wordprss!',
     'guid'=>'FAKEGUID',
     'link'=>'http://mattkatz.github.com/Wordprss/welcome.html',//TODO 
-    'updated'=>date ("Y-m-d H:m:s"),
+    'updated'=>date ("Y-m-d H:i:s"),
     'content'=>"Here is where I'll put in some helpful stuff to look at",//TODO
-    'entered' =>date ("Y-m-d H:m:s"), 
+    'entered' =>date ("Y-m-d H:i:s"),
     'author' => 'Matt Katz'
   ));
   for ($i = 1; $i <= 120; $i++) {
@@ -145,9 +145,9 @@ function wprss_install_data(){
       'title'=>'Entry number ' . $i,
       'guid'=>'FAKEGUID'.$i,
       'link'=>'http://mattkatz.github.com/Wordprss/welcome.html',//TODO 
-      'updated'=>date ("Y-m-d H:m:s"),
+      'updated'=>date ("Y-m-d H:i:s"),
       'content'=>"Here is where I'll put in some helpful stuff to look at\n \n Lorem Ipusm and so forth\n and so on.",//TODO
-      'entered' =>date ("Y-m-d H:m:s"), 
+      'entered' =>date ("Y-m-d H:i:s"),
       'author' => 'Matt Katz'
     ));
     $i++;
@@ -159,9 +159,9 @@ function wprss_install_data(){
     'title'=>'Look at this fake post about a banana',
     'guid'=>'FAKEGUID2',
     'link'=>'http://boingboing.net/',//TODO 
-    'updated'=>date ("Y-m-d H:m:s"),
+    'updated'=>date ("Y-m-d H:i:s"),
     'content'=>"just LOOK AT IT.<br/>Amazing, really how this meme caught on.",//TODO
-    'entered' =>date ("Y-m-d H:m:s"), 
+    'entered' =>date ("Y-m-d H:i:s"),
     'author' => 'Cory Doctorow'
   ));
 


### PR DESCRIPTION
PHP's date formatter uses "m" for months, so `H:m:s` translates
to hours-months-seconds. The correct format string should be `H:i:s`.
